### PR TITLE
set prefix in nccl build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ echo ========== BUILDING NCCL ==========
 if [ ! -e nccl ]; then
     git clone --branch v2.17.1-1 https://github.com/NVIDIA/nccl.git
     cd nccl
-    make -j $N src.build
+    make -j $N PREFIX=$NCCL_HOME src.build
     make PREFIX=$NCCL_HOME install
     cd ..
 else


### PR DESCRIPTION
This fixes the prefix path set in the generated pkgconfig